### PR TITLE
Adicionar plugins SonarQube e Jacoco para qualidade do código no build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.0'
+    id "org.sonarqube" version "4.2.1.3168"
+    id "jacoco"
 }
 
 group = 'com.project'
@@ -42,4 +44,10 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
 }


### PR DESCRIPTION
Descrição:

Este pull request adiciona os plugins SonarQube e Jacoco ao arquivo build.gradle, melhorando a qualidade do código do projeto.

As seguintes alterações foram feitas:

Adicionado o plugin org.sonarqube na versão 4.2.1.3168
Adicionado o plugin jacoco
Essas adições oferecem os seguintes benefícios:

O plugin SonarQube permite análise e relatórios de código, ajudando a identificar e resolver problemas de qualidade.
O plugin Jacoco gera relatórios de cobertura de código, fornecendo insights sobre a extensão da cobertura de testes.
Essa atualização é importante para manter e melhorar a qualidade geral do código do projeto. Ela garante que o projeto siga as melhores práticas e aprimore a análise de cobertura de testes.